### PR TITLE
Read elm-analyse configuration from the directory where the elm.json …

### DIFF
--- a/ts/ports/context.ts
+++ b/ts/ports/context.ts
@@ -1,13 +1,14 @@
 import * as fs from 'fs';
 import * as fileGatherer from '../util/file-gatherer';
 import { ElmApp, Context } from '../domain';
+import * as path from 'path';
 
 function setup(app: ElmApp, directory: string) {
     app.ports.loadContext.subscribe(() => {
         const input = fileGatherer.gather(directory);
         var configuration;
         try {
-            configuration = fs.readFileSync('./elm-analyse.json').toString();
+            configuration = fs.readFileSync(path.join(directory, 'elm-analyse.json')).toString();
         } catch (e) {
             configuration = '';
         }


### PR DESCRIPTION
…is rather than the current working directory of the process.  This helps with running in a multi-project structure where you may open "/project/" in an editor and have an elm project under "/project/web/".